### PR TITLE
Limit concurrent topic publishes to prevent overload

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.hazelcast.internal.cluster.Versions.V5_4;
+import static com.hazelcast.internal.cluster.Versions.V6_0;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableList;
 import static com.hazelcast.internal.util.Preconditions.checkHasText;
@@ -52,6 +53,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
     private boolean multiThreadingEnabled;
     private List<ListenerConfig> listenerConfigs;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishes = -1;
 
     /**
      * Creates a TopicConfig.
@@ -80,6 +82,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         this.multiThreadingEnabled = config.multiThreadingEnabled;
         this.listenerConfigs = new ArrayList<>(config.getMessageListenerConfigs());
         this.userCodeNamespace = config.userCodeNamespace;
+        this.maxConcurrentPublishes = config.maxConcurrentPublishes;
     }
 
     /**
@@ -218,6 +221,32 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
     }
 
     /**
+     * Returns the maximum number of concurrent publish operations allowed for
+     * this topic. A value of {@code -1} means the limit is not set and the
+     * cluster-wide default will be used.
+     */
+    public int getMaxConcurrentPublishes() {
+        return maxConcurrentPublishes;
+    }
+
+    /**
+     * Sets the maximum number of concurrent publish operations allowed for this
+     * topic. The provided limit must be a non-negative integer. When not set,
+     * the cluster-wide default value is used.
+     *
+     * @param maxConcurrentPublishes the non-negative limit
+     * @return the updated TopicConfig
+     * @throws IllegalArgumentException if {@code maxConcurrentPublishes} is negative
+     */
+    public TopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        if (maxConcurrentPublishes < 0) {
+            throw new IllegalArgumentException("maxConcurrentPublishes must be a non-negative integer");
+        }
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
+        return this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -258,6 +287,9 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         if (statisticsEnabled != that.statisticsEnabled) {
             return false;
         }
+        if (maxConcurrentPublishes != that.maxConcurrentPublishes) {
+            return false;
+        }
         if (multiThreadingEnabled != that.multiThreadingEnabled) {
             return false;
         }
@@ -282,6 +314,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (globalOrderingEnabled ? 1 : 0);
         result = 31 * result + (statisticsEnabled ? 1 : 0);
+        result = 31 * result + maxConcurrentPublishes;
         result = 31 * result + (multiThreadingEnabled ? 1 : 0);
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
@@ -295,6 +328,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
                 + ", multiThreadingEnabled=" + multiThreadingEnabled
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishes=" + maxConcurrentPublishes
                 + "]";
     }
 
@@ -320,6 +354,11 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
             out.writeString(userCodeNamespace);
         }
+
+        // RU_COMPAT_5_5
+        if (out.getVersion().isGreaterOrEqual(V6_0)) {
+            out.writeInt(maxConcurrentPublishes);
+        }
     }
 
     @Override
@@ -333,6 +372,11 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
             userCodeNamespace = in.readString();
+        }
+
+        // RU_COMPAT_5_5
+        if (in.getVersion().isGreaterOrEqual(V6_0)) {
+            maxConcurrentPublishes = in.readInt();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/TopicConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/TopicConfigReadOnly.java
@@ -77,4 +77,9 @@ public class TopicConfigReadOnly extends TopicConfig {
     public TopicConfig setUserCodeNamespace(@Nullable String userCodeNamespace) {
         throw new UnsupportedOperationException("This config is read-only topic: " + getName());
     }
+
+    @Override
+    public TopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        throw new UnsupportedOperationException("This config is read-only topic: " + getName());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReliableTopicMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReliableTopicMBean.java
@@ -49,6 +49,18 @@ public class ReliableTopicMBean extends HazelcastMBean<ReliableTopicProxy> {
         return managedObject.getLocalTopicStats().getReceiveOperationCount();
     }
 
+    @ManagedAnnotation("localPublishOperationRejectedCount")
+    @ManagedDescription("the number of publish operations rejected due to exceeding the limit on this member")
+    public long getLocalPublishOperationRejectedCount() {
+        return managedObject.getLocalTopicStats().getPublishOperationRejectedCount();
+    }
+
+    @ManagedAnnotation("localInFlightPublishOperationCount")
+    @ManagedDescription("the current number of in-flight publish operations on this member")
+    public long getLocalInFlightPublishOperationCount() {
+        return managedObject.getLocalTopicStats().getInFlightPublishOperationCount();
+    }
+
     @ManagedAnnotation("name")
     @ManagedDescription("Name of the DistributedObject")
     public String getName() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/TopicMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/TopicMBean.java
@@ -49,6 +49,18 @@ public class TopicMBean extends HazelcastMBean<ITopic> {
         return managedObject.getLocalTopicStats().getReceiveOperationCount();
     }
 
+    @ManagedAnnotation("localPublishOperationRejectedCount")
+    @ManagedDescription("the number of publish operations rejected due to exceeding the limit on this member")
+    public long getLocalPublishOperationRejectedCount() {
+        return managedObject.getLocalTopicStats().getPublishOperationRejectedCount();
+    }
+
+    @ManagedAnnotation("localInFlightPublishOperationCount")
+    @ManagedDescription("the current number of in-flight publish operations on this member")
+    public long getLocalInFlightPublishOperationCount() {
+        return managedObject.getLocalTopicStats().getInFlightPublishOperationCount();
+    }
+
     @ManagedAnnotation("name")
     @ManagedDescription("Name of the DistributedObject")
     public String getName() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -577,6 +577,8 @@ public final class MetricDescriptorConstants {
     public static final String TOPIC_METRIC_CREATION_TIME = "creationTime";
     public static final String TOPIC_METRIC_TOTAL_PUBLISHES = "totalPublishes";
     public static final String TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES = "totalReceivedMessages";
+    public static final String TOPIC_METRIC_REJECTED_PUBLISHES = "rejectedPublishes";
+    public static final String TOPIC_METRIC_IN_FLIGHT_PUBLISHES = "inFlightPublishes";
     // ===[/TOPIC]=======================================================
 
     // ===[TRANSACTIONS]================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
@@ -24,6 +24,8 @@ import com.hazelcast.topic.impl.reliable.ReliableMessageRunner;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_CREATION_TIME;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_IN_FLIGHT_PUBLISHES;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_REJECTED_PUBLISHES;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_TOTAL_PUBLISHES;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
@@ -35,6 +37,10 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
             newUpdater(LocalTopicStatsImpl.class, "totalPublishes");
     private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_RECEIVED_MESSAGES =
             newUpdater(LocalTopicStatsImpl.class, "totalReceivedMessages");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> IN_FLIGHT_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "inFlightPublishes");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> REJECTED_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "rejectedPublishes");
     @Probe(name = TOPIC_METRIC_CREATION_TIME, unit = MS)
     private final long creationTime;
 
@@ -43,6 +49,10 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     private volatile long totalPublishes;
     @Probe(name = TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES)
     private volatile long totalReceivedMessages;
+    @Probe(name = TOPIC_METRIC_IN_FLIGHT_PUBLISHES)
+    private volatile long inFlightPublishes;
+    @Probe(name = TOPIC_METRIC_REJECTED_PUBLISHES)
+    private volatile long rejectedPublishes;
 
     public LocalTopicStatsImpl() {
         creationTime = Clock.currentTimeMillis();
@@ -75,6 +85,16 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         return totalReceivedMessages;
     }
 
+    @Override
+    public long getPublishOperationRejectedCount() {
+        return rejectedPublishes;
+    }
+
+    @Override
+    public long getInFlightPublishOperationCount() {
+        return inFlightPublishes;
+    }
+
     /**
      * Increment the number of locally received messages. The count can be local
      * to the member or local to a single listener (whereas there are many listeners
@@ -87,12 +107,36 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }
 
+    /**
+     * Increments the number of in-flight publish operations and returns the
+     * updated count.
+     */
+    public long incrementInFlightPublishes() {
+        return IN_FLIGHT_PUBLISHES.incrementAndGet(this);
+    }
+
+    /**
+     * Decrements the number of in-flight publish operations.
+     */
+    public void decrementInFlightPublishes() {
+        IN_FLIGHT_PUBLISHES.decrementAndGet(this);
+    }
+
+    /**
+     * Increments the number of rejected publish operations.
+     */
+    public void incrementRejectedPublishes() {
+        REJECTED_PUBLISHES.incrementAndGet(this);
+    }
+
     @Override
     public String toString() {
         return "LocalTopicStatsImpl{"
                 + "creationTime=" + creationTime
                 + ", totalPublishes=" + totalPublishes
                 + ", totalReceivedMessages=" + totalReceivedMessages
+                + ", inFlightPublishes=" + inFlightPublishes
+                + ", rejectedPublishes=" + rejectedPublishes
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1318,6 +1318,13 @@ public final class ClusterProperty {
     public static final HazelcastProperty MAP_WRITE_BEHIND_QUEUE_CAPACITY
             = new HazelcastProperty("hazelcast.map.write.behind.queue.capacity", 50000);
 
+    /**
+     * Cluster-wide default maximum number of concurrent publish operations per topic.
+     * A negative value disables the limit.
+     */
+    public static final HazelcastProperty TOPIC_MAX_CONCURRENT_PUBLISHES
+            = new HazelcastProperty("hazelcast.topic.max.concurrent.publishes", -1);
+
     /*
      * INVOCATION / OPERATION SYSTEM PROPERTIES
      */

--- a/hazelcast/src/main/java/com/hazelcast/topic/LocalTopicStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/LocalTopicStats.java
@@ -45,4 +45,20 @@ public interface LocalTopicStats extends LocalInstanceStats {
      * @return total number of received messages of this topic on this member
      */
     long getReceiveOperationCount();
+
+    /**
+     * Returns the number of publish operations rejected because the configured
+     * concurrency limit was exceeded.
+     *
+     * @return the number of rejected publish operations on this member
+     */
+    long getPublishOperationRejectedCount();
+
+    /**
+     * Returns the number of in-flight publish operations currently executing
+     * on this member.
+     *
+     * @return the current number of in-flight publish operations on this member
+     */
+    long getInFlightPublishOperationCount();
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishAllOperation.java
@@ -57,17 +57,24 @@ public class PublishAllOperation extends AbstractNamedOperation
         TopicService service = getService();
         EventService eventService = getNodeEngine().getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(TopicService.SERVICE_NAME, name);
-
-        Lock lock = service.getOrderLock(name);
-        lock.lock();
+        if (registrations.isEmpty()) {
+            return;
+        }
+        service.beginPublish(name);
         try {
-            for (Data item : messages) {
-                TopicEvent topicEvent = new TopicEvent(name, item, getCallerAddress());
-                eventService.publishEvent(TopicService.SERVICE_NAME, registrations, topicEvent, name.hashCode());
-                service.incrementPublishes(name);
+            Lock lock = service.getOrderLock(name);
+            lock.lock();
+            try {
+                for (Data item : messages) {
+                    TopicEvent topicEvent = new TopicEvent(name, item, getCallerAddress());
+                    eventService.publishEvent(TopicService.SERVICE_NAME, registrations, topicEvent, name.hashCode());
+                    service.incrementPublishes(name);
+                }
+            } finally {
+                lock.unlock();
             }
         } finally {
-            lock.unlock();
+            service.endPublish(name);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -66,16 +66,23 @@ public class PublishOperation extends AbstractNamedOperation
     @Override
     public void run() throws Exception {
         TopicService service = getService();
-        TopicEvent topicEvent = new TopicEvent(name, message, getCallerAddress());
         EventService eventService = getNodeEngine().getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(TopicService.SERVICE_NAME, name);
-
-        Lock lock = service.getOrderLock(name);
-        lock.lock();
+        if (registrations.isEmpty()) {
+            return;
+        }
+        service.beginPublish(name);
         try {
-            eventService.publishEvent(TopicService.SERVICE_NAME, registrations, topicEvent, name.hashCode());
+            TopicEvent topicEvent = new TopicEvent(name, message, getCallerAddress());
+            Lock lock = service.getOrderLock(name);
+            lock.lock();
+            try {
+                eventService.publishEvent(TopicService.SERVICE_NAME, registrations, topicEvent, name.hashCode());
+            } finally {
+                lock.unlock();
+            }
         } finally {
-            lock.unlock();
+            service.endPublish(name);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -42,6 +42,7 @@ import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
+import com.hazelcast.topic.TopicOverloadException;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
@@ -76,6 +77,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     private EventService eventService;
     private final AtomicInteger counter = new AtomicInteger();
     private Address localAddress;
+    private int defaultMaxConcurrentPublishes;
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
@@ -85,6 +87,9 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
             orderingLocks[i] = new ReentrantLock();
         }
         eventService = nodeEngine.getEventService();
+
+        defaultMaxConcurrentPublishes = nodeEngine.getProperties()
+                .getInteger(ClusterProperty.TOPIC_MAX_CONCURRENT_PUBLISHES);
 
         boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
         if (dsMetricsEnabled) {
@@ -176,13 +181,42 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
         getLocalTopicStats(topicName).incrementReceives();
     }
 
+    private int getPublishLimit(String topicName) {
+        TopicConfig config = nodeEngine.getConfig().findTopicConfig(topicName);
+        int limit = config.getMaxConcurrentPublishes();
+        if (limit < 0) {
+            limit = defaultMaxConcurrentPublishes;
+        }
+        return limit;
+    }
+
+    void beginPublish(String topicName) {
+        LocalTopicStatsImpl stats = getLocalTopicStats(topicName);
+        long inFlight = stats.incrementInFlightPublishes();
+        int limit = getPublishLimit(topicName);
+        if (limit >= 0 && inFlight > limit) {
+            stats.decrementInFlightPublishes();
+            stats.incrementRejectedPublishes();
+            throw new TopicOverloadException("Concurrent publish limit exceeded for topic " + topicName);
+        }
+    }
+
+    void endPublish(String topicName) {
+        getLocalTopicStats(topicName).decrementInFlightPublishes();
+    }
+
     public void publishMessage(String topicName, Object payload, boolean multithreaded) {
         Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, topicName);
         if (!registrations.isEmpty()) {
-            Data payloadData = nodeEngine.toData(payload);
-            TopicEvent topicEvent = new TopicEvent(topicName, payloadData, localAddress);
-            int partitionId = multithreaded ? counter.incrementAndGet() : topicName.hashCode();
-            eventService.publishEvent(SERVICE_NAME, registrations, topicEvent, partitionId);
+            beginPublish(topicName);
+            try {
+                Data payloadData = nodeEngine.toData(payload);
+                TopicEvent topicEvent = new TopicEvent(topicName, payloadData, localAddress);
+                int partitionId = multithreaded ? counter.incrementAndGet() : topicName.hashCode();
+                eventService.publishEvent(SERVICE_NAME, registrations, topicEvent, partitionId);
+            } finally {
+                endPublish(topicName);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add optional per-topic limit for concurrent publishes with cluster-wide default
- track in-flight and rejected publishes in topic stats and expose metrics
- enforce publish limit, rejecting excess with `TopicOverloadException`

## Testing
- `mvn -q -pl hazelcast -am test -Dtest=LocalTopicStatsImplTest,TopicConfigTest` *(fails: Plugin co.leantechniques:maven-buildtime-extension:3.0.5 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a7510451908326973c1fc17f78ddc1