### PR TITLE
Add configurable concurrency limit for topic publish operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.hazelcast.internal.cluster.Versions.V5_4;
+import static com.hazelcast.internal.cluster.Versions.V6_0;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableList;
 import static com.hazelcast.internal.util.Preconditions.checkHasText;
@@ -52,6 +53,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
     private boolean multiThreadingEnabled;
     private List<ListenerConfig> listenerConfigs;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishOperations = -1;
 
     /**
      * Creates a TopicConfig.
@@ -80,6 +82,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         this.multiThreadingEnabled = config.multiThreadingEnabled;
         this.listenerConfigs = new ArrayList<>(config.getMessageListenerConfigs());
         this.userCodeNamespace = config.userCodeNamespace;
+        this.maxConcurrentPublishOperations = config.maxConcurrentPublishOperations;
     }
 
     /**
@@ -161,6 +164,30 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
             throw new IllegalArgumentException("Multi-threading can not be enabled when global ordering is used.");
         }
         this.multiThreadingEnabled = multiThreadingEnabled;
+        return this;
+    }
+
+    /**
+     * Returns the maximum number of concurrent publish operations allowed for this topic.
+     * A negative value means there is no limit.
+     */
+    public int getMaxConcurrentPublishOperations() {
+        return maxConcurrentPublishOperations;
+    }
+
+    /**
+     * Sets the maximum number of concurrent publish operations allowed for this topic.
+     * A non-negative value enables limiting; a negative value disables it.
+     *
+     * @param maxConcurrentPublishOperations maximum allowed concurrent publishes
+     * @return the updated TopicConfig
+     * @throws IllegalArgumentException if {@code maxConcurrentPublishOperations} is negative
+     */
+    public TopicConfig setMaxConcurrentPublishOperations(int maxConcurrentPublishOperations) {
+        if (maxConcurrentPublishOperations < 0) {
+            throw new IllegalArgumentException("maxConcurrentPublishOperations must be >= 0");
+        }
+        this.maxConcurrentPublishOperations = maxConcurrentPublishOperations;
         return this;
     }
 
@@ -273,6 +300,9 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         if (!Objects.equals(userCodeNamespace, that.userCodeNamespace)) {
             return false;
         }
+        if (maxConcurrentPublishOperations != that.maxConcurrentPublishOperations) {
+            return false;
+        }
         return name != null ? name.equals(that.name) : that.name == null;
     }
 
@@ -285,6 +315,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         result = 31 * result + (multiThreadingEnabled ? 1 : 0);
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
+        result = 31 * result + maxConcurrentPublishOperations;
         return result;
     }
 
@@ -295,6 +326,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
                 + ", multiThreadingEnabled=" + multiThreadingEnabled
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishOperations=" + maxConcurrentPublishOperations
                 + "]";
     }
 
@@ -320,6 +352,9 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
             out.writeString(userCodeNamespace);
         }
+        if (out.getVersion().isGreaterOrEqual(V6_0)) {
+            out.writeInt(maxConcurrentPublishOperations);
+        }
     }
 
     @Override
@@ -333,6 +368,9 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
             userCodeNamespace = in.readString();
+        }
+        if (in.getVersion().isGreaterOrEqual(V6_0)) {
+            maxConcurrentPublishOperations = in.readInt();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MemberDomConfigProcessor.java
@@ -2701,6 +2701,9 @@ public class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 tConfig.setMultiThreadingEnabled(getBooleanValue(getTextContent(n)));
             } else if (matches("user-code-namespace", nodeName)) {
                 tConfig.setUserCodeNamespace(getTextContent(n));
+            } else if (matches("max-concurrent-publish-operations", nodeName)) {
+                tConfig.setMaxConcurrentPublishOperations(getIntegerValue(
+                        "max-concurrent-publish-operations", getTextContent(n)));
             }
         }
         config.addTopicConfig(tConfig);

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/TopicConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/TopicConfigReadOnly.java
@@ -77,4 +77,9 @@ public class TopicConfigReadOnly extends TopicConfig {
     public TopicConfig setUserCodeNamespace(@Nullable String userCodeNamespace) {
         throw new UnsupportedOperationException("This config is read-only topic: " + getName());
     }
+
+    @Override
+    public TopicConfig setMaxConcurrentPublishOperations(int maxConcurrentPublishOperations) {
+        throw new UnsupportedOperationException("This config is read-only topic: " + getName());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -717,7 +717,7 @@ public class ClusterWideConfigurationService implements
         configToVersion.put(ListConfig.class, V4_0);
         configToVersion.put(SetConfig.class, V4_0);
         configToVersion.put(ReplicatedMapConfig.class, V4_0);
-        configToVersion.put(TopicConfig.class, V4_0);
+        configToVersion.put(TopicConfig.class, V6_0);
         configToVersion.put(ExecutorConfig.class, V4_0);
         configToVersion.put(DurableExecutorConfig.class, V4_0);
         configToVersion.put(ScheduledExecutorConfig.class, V4_0);

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigXmlGenerator.java
@@ -330,6 +330,9 @@ public final class DynamicConfigXmlGenerator {
             if (t.getUserCodeNamespace() != null) {
                 gen.node("user-code-namespace", t.getUserCodeNamespace());
             }
+            if (t.getMaxConcurrentPublishOperations() >= 0) {
+                gen.node("max-concurrent-publish-operations", t.getMaxConcurrentPublishOperations());
+            }
             gen.close();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigYamlGenerator.java
@@ -510,6 +510,10 @@ public class DynamicConfigYamlGenerator {
             addNonNullToMap(subConfigAsMap, "multi-threading-enabled",
                     subConfigAsObject.isMultiThreadingEnabled());
             addNonNullToMap(subConfigAsMap, "user-code-namespace", subConfigAsObject.getUserCodeNamespace());
+            if (subConfigAsObject.getMaxConcurrentPublishOperations() >= 0) {
+                addNonNullToMap(subConfigAsMap, "max-concurrent-publish-operations",
+                        subConfigAsObject.getMaxConcurrentPublishOperations());
+            }
 
             child.put(subConfigAsObject.getName(), subConfigAsMap);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -577,6 +577,8 @@ public final class MetricDescriptorConstants {
     public static final String TOPIC_METRIC_CREATION_TIME = "creationTime";
     public static final String TOPIC_METRIC_TOTAL_PUBLISHES = "totalPublishes";
     public static final String TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES = "totalReceivedMessages";
+    public static final String TOPIC_METRIC_REJECTED_PUBLISHES = "rejectedPublishes";
+    public static final String TOPIC_METRIC_IN_FLIGHT_PUBLISHES = "inFlightPublishes";
     // ===[/TOPIC]=======================================================
 
     // ===[TRANSACTIONS]================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
@@ -26,6 +26,8 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_CREATION_TIME;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_TOTAL_PUBLISHES;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_REJECTED_PUBLISHES;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_IN_FLIGHT_PUBLISHES;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
@@ -35,6 +37,10 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
             newUpdater(LocalTopicStatsImpl.class, "totalPublishes");
     private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_RECEIVED_MESSAGES =
             newUpdater(LocalTopicStatsImpl.class, "totalReceivedMessages");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> REJECTED_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "rejectedPublishes");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> IN_FLIGHT_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "inFlightPublishes");
     @Probe(name = TOPIC_METRIC_CREATION_TIME, unit = MS)
     private final long creationTime;
 
@@ -43,6 +49,10 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     private volatile long totalPublishes;
     @Probe(name = TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES)
     private volatile long totalReceivedMessages;
+    @Probe(name = TOPIC_METRIC_REJECTED_PUBLISHES)
+    private volatile long rejectedPublishes;
+    @Probe(name = TOPIC_METRIC_IN_FLIGHT_PUBLISHES)
+    private volatile long inFlightPublishes;
 
     public LocalTopicStatsImpl() {
         creationTime = Clock.currentTimeMillis();
@@ -76,6 +86,22 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     }
 
     /**
+     * Returns number of publish operations rejected because concurrency limit was exceeded.
+     */
+    @Override
+    public long getRejectedPublishOperationCount() {
+        return rejectedPublishes;
+    }
+
+    /**
+     * Returns current number of in-flight publish operations for this topic.
+     */
+    @Override
+    public long getInFlightPublishOperationCount() {
+        return inFlightPublishes;
+    }
+
+    /**
      * Increment the number of locally received messages. The count can be local
      * to the member or local to a single listener (whereas there are many listeners
      * on one member).
@@ -87,12 +113,26 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }
 
+    public void incrementRejectedPublishes() {
+        REJECTED_PUBLISHES.incrementAndGet(this);
+    }
+
+    public void incrementInFlightPublishes() {
+        IN_FLIGHT_PUBLISHES.incrementAndGet(this);
+    }
+
+    public void decrementInFlightPublishes() {
+        IN_FLIGHT_PUBLISHES.decrementAndGet(this);
+    }
+
     @Override
     public String toString() {
         return "LocalTopicStatsImpl{"
                 + "creationTime=" + creationTime
                 + ", totalPublishes=" + totalPublishes
                 + ", totalReceivedMessages=" + totalReceivedMessages
+                + ", rejectedPublishes=" + rejectedPublishes
+                + ", inFlightPublishes=" + inFlightPublishes
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/ClusterProperty.java
@@ -1589,6 +1589,13 @@ public final class ClusterProperty {
             = new HazelcastProperty("hazelcast.event.queue.capacity", 1000000);
 
     /**
+     * The maximum number of concurrent publish operations allowed per topic.
+     * A negative value disables the limit.
+     */
+    public static final HazelcastProperty TOPIC_MAX_CONCURRENT_PUBLISH_OPERATIONS
+            = new HazelcastProperty("hazelcast.topic.max.concurrent.operations", -1);
+
+    /**
      * The timeout for offering an event to the event executor for processing.
      * If the event queue is full, the event might not be accepted to the queue,
      * and it will be dropped.

--- a/hazelcast/src/main/java/com/hazelcast/topic/LocalTopicStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/LocalTopicStats.java
@@ -45,4 +45,24 @@ public interface LocalTopicStats extends LocalInstanceStats {
      * @return total number of received messages of this topic on this member
      */
     long getReceiveOperationCount();
+
+    /**
+     * Returns the number of publish operations that were rejected due to
+     * exceeding configured concurrency limits.
+     *
+     * @return rejected publish operation count
+     */
+    default long getRejectedPublishOperationCount() {
+        return 0;
+    }
+
+    /**
+     * Returns the current number of in-flight publish operations of this
+     * topic on this member.
+     *
+     * @return in-flight publish operation count
+     */
+    default long getInFlightPublishOperationCount() {
+        return 0;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishAllOperation.java
@@ -22,13 +22,10 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.eventservice.EventRegistration;
-import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -55,15 +52,11 @@ public class PublishAllOperation extends AbstractNamedOperation
     @Override
     public void run() throws Exception {
         TopicService service = getService();
-        EventService eventService = getNodeEngine().getEventService();
-        Collection<EventRegistration> registrations = eventService.getRegistrations(TopicService.SERVICE_NAME, name);
-
         Lock lock = service.getOrderLock(name);
         lock.lock();
         try {
             for (Data item : messages) {
-                TopicEvent topicEvent = new TopicEvent(name, item, getCallerAddress());
-                eventService.publishEvent(TopicService.SERVICE_NAME, registrations, topicEvent, name.hashCode());
+                service.publishMessage(name, item, false);
                 service.incrementPublishes(name);
             }
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -22,12 +22,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.eventservice.EventRegistration;
-import com.hazelcast.spi.impl.eventservice.EventService;
 import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -66,14 +63,10 @@ public class PublishOperation extends AbstractNamedOperation
     @Override
     public void run() throws Exception {
         TopicService service = getService();
-        TopicEvent topicEvent = new TopicEvent(name, message, getCallerAddress());
-        EventService eventService = getNodeEngine().getEventService();
-        Collection<EventRegistration> registrations = eventService.getRegistrations(TopicService.SERVICE_NAME, name);
-
         Lock lock = service.getOrderLock(name);
         lock.lock();
         try {
-            eventService.publishEvent(TopicService.SERVICE_NAME, registrations, topicEvent, name.hashCode());
+            service.publishMessage(name, message, false);
         } finally {
             lock.unlock();
         }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -37,7 +37,10 @@ import com.hazelcast.spi.impl.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.EventPublishingService;
 import com.hazelcast.spi.impl.eventservice.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.EventService;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.internal.util.executor.StripedRunnable;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.Message;
@@ -68,14 +71,18 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     public static final int ORDERING_LOCKS_LENGTH = 1000;
 
     private final ConcurrentMap<String, LocalTopicStatsImpl> statsMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, PublishLimiter> publishLimiters = new ConcurrentHashMap<>();
     private final Lock[] orderingLocks = new Lock[ORDERING_LOCKS_LENGTH];
     private NodeEngine nodeEngine;
 
     private final ConstructorFunction<String, LocalTopicStatsImpl> localTopicStatsConstructorFunction =
             mapName -> new LocalTopicStatsImpl();
+    private final ConstructorFunction<String, PublishLimiter> publishLimiterConstructor =
+            name -> new PublishLimiter(resolveLimit(name), getLocalTopicStats(name));
     private EventService eventService;
     private final AtomicInteger counter = new AtomicInteger();
     private Address localAddress;
+    private int defaultMaxConcurrentPublishes;
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
@@ -85,6 +92,8 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
             orderingLocks[i] = new ReentrantLock();
         }
         eventService = nodeEngine.getEventService();
+        defaultMaxConcurrentPublishes = nodeEngine.getProperties()
+                .getInteger(ClusterProperty.TOPIC_MAX_CONCURRENT_PUBLISH_OPERATIONS);
 
         boolean dsMetricsEnabled = nodeEngine.getProperties().getBoolean(ClusterProperty.METRICS_DATASTRUCTURES);
         if (dsMetricsEnabled) {
@@ -100,6 +109,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     @Override
     public void reset() {
         statsMap.clear();
+        publishLimiters.clear();
     }
 
     @Override
@@ -131,6 +141,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     @Override
     public void destroyDistributedObject(String objectId, boolean local) {
         statsMap.remove(objectId);
+        publishLimiters.remove(objectId);
         nodeEngine.getEventService().deregisterAllLocalListeners(SERVICE_NAME, objectId);
     }
 
@@ -178,11 +189,86 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
 
     public void publishMessage(String topicName, Object payload, boolean multithreaded) {
         Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, topicName);
-        if (!registrations.isEmpty()) {
-            Data payloadData = nodeEngine.toData(payload);
-            TopicEvent topicEvent = new TopicEvent(topicName, payloadData, localAddress);
-            int partitionId = multithreaded ? counter.incrementAndGet() : topicName.hashCode();
+        if (registrations.isEmpty()) {
+            return;
+        }
+        PublishLimiter limiter = getPublishLimiter(topicName);
+        if (!limiter.tryAcquire()) {
+            limiter.stats.incrementRejectedPublishes();
+            throw new HazelcastOverloadException("Too many concurrent publishes for topic: " + topicName);
+        }
+        Data payloadData = nodeEngine.toData(payload);
+        TopicEvent topicEvent = new TopicEvent(topicName, payloadData, localAddress);
+        int partitionId = multithreaded ? counter.incrementAndGet() : topicName.hashCode();
+        try {
             eventService.publishEvent(SERVICE_NAME, registrations, topicEvent, partitionId);
+        } finally {
+            schedulePermitRelease(limiter, partitionId);
+        }
+    }
+
+    private PublishLimiter getPublishLimiter(String topicName) {
+        return getOrPutSynchronized(publishLimiters, topicName, publishLimiters, publishLimiterConstructor);
+    }
+
+    private int resolveLimit(String topicName) {
+        TopicConfig topicConfig = nodeEngine.getConfig().findTopicConfig(topicName);
+        int limit = topicConfig.getMaxConcurrentPublishOperations();
+        if (limit < 0) {
+            limit = defaultMaxConcurrentPublishes;
+        }
+        return limit;
+    }
+
+    private void schedulePermitRelease(PublishLimiter limiter, int orderKey) {
+        StripedRunnable callback = new StripedRunnable() {
+            @Override
+            public void run() {
+                limiter.release();
+            }
+
+            @Override
+            public int getKey() {
+                return orderKey;
+            }
+        };
+        try {
+            if (eventService instanceof EventServiceImpl) {
+                ((EventServiceImpl) eventService).executeEventCallback(callback, true);
+            } else {
+                eventService.executeEventCallback(callback);
+            }
+        } catch (Throwable t) {
+            limiter.release();
+        }
+    }
+
+    private static final class PublishLimiter {
+        final int limit;
+        final AtomicInteger inFlight = new AtomicInteger();
+        final LocalTopicStatsImpl stats;
+
+        PublishLimiter(int limit, LocalTopicStatsImpl stats) {
+            this.limit = limit;
+            this.stats = stats;
+        }
+
+        boolean tryAcquire() {
+            for (;;) {
+                int current = inFlight.get();
+                if (limit >= 0 && current >= limit) {
+                    return false;
+                }
+                if (inFlight.compareAndSet(current, current + 1)) {
+                    stats.incrementInFlightPublishes();
+                    return true;
+                }
+            }
+        }
+
+        void release() {
+            inFlight.decrementAndGet();
+            stats.decrementInFlightPublishes();
         }
     }
 


### PR DESCRIPTION
## Summary
- add per-topic and cluster-wide limits on concurrent publish operations
- track in-flight and rejected publishes in local topic stats and metrics
- support new `maxConcurrentPublishOperations` option in topic configuration and dynamic config

## Testing
- ⚠️ `mvn -q -pl hazelcast -am test -Dtest=LocalTopicStatsImplTest,TopicConfigTest` *(dependency resolution failure: Plugin co.leantechniques:maven-buildtime-extension:3.0.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a75b5160988326a9f359767d6c376f