### PR TITLE
Add publish concurrency control for reliable topics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -82,15 +82,26 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
     private List<ListenerConfig> listenerConfigs = new LinkedList<>();
     private TopicOverloadPolicy topicOverloadPolicy = DEFAULT_TOPIC_OVERLOAD_POLICY;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishes = -1;
 
     public ReliableTopicConfig() {
+        this(-1);
+    }
+
+    public ReliableTopicConfig(int maxConcurrentPublishes) {
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
     }
 
     /**
      * Creates a new ReliableTopicConfig with default settings.
      */
     public ReliableTopicConfig(String name) {
+        this(name, -1);
+    }
+
+    public ReliableTopicConfig(String name, int maxConcurrentPublishes) {
         this.name = checkNotNull(name, "name");
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
     }
 
     /**
@@ -99,6 +110,10 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      * @param config the ReliableTopicConfig to clone
      */
     public ReliableTopicConfig(ReliableTopicConfig config) {
+        this(config, config.maxConcurrentPublishes);
+    }
+
+    public ReliableTopicConfig(ReliableTopicConfig config, int maxConcurrentPublishes) {
         this.name = config.name;
         this.statisticsEnabled = config.statisticsEnabled;
         this.readBatchSize = config.readBatchSize;
@@ -106,6 +121,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         this.topicOverloadPolicy = config.topicOverloadPolicy;
         this.listenerConfigs = config.listenerConfigs;
         this.userCodeNamespace = config.userCodeNamespace;
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
     }
 
     ReliableTopicConfig(ReliableTopicConfig config, String name) {
@@ -155,6 +171,18 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      */
     public ReliableTopicConfig setTopicOverloadPolicy(TopicOverloadPolicy topicOverloadPolicy) {
         this.topicOverloadPolicy = checkNotNull(topicOverloadPolicy, "topicOverloadPolicy can't be null");
+        return this;
+    }
+
+    public int getMaxConcurrentPublishes() {
+        return maxConcurrentPublishes;
+    }
+
+    public ReliableTopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        if (maxConcurrentPublishes < -1) {
+            throw new IllegalArgumentException("maxConcurrentPublishes must be >= -1");
+        }
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
         return this;
     }
 
@@ -335,6 +363,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", listenerConfigs=" + listenerConfigs
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishes=" + maxConcurrentPublishes
                 + '}';
     }
 
@@ -356,6 +385,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         out.writeBoolean(statisticsEnabled);
         writeNullableList(listenerConfigs, out);
         out.writeString(topicOverloadPolicy.name());
+        out.writeInt(maxConcurrentPublishes);
 
         // RU_COMPAT_5_3
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
@@ -371,6 +401,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         statisticsEnabled = in.readBoolean();
         listenerConfigs = readNullableList(in);
         topicOverloadPolicy = TopicOverloadPolicy.valueOf(in.readString());
+        maxConcurrentPublishes = in.readInt();
 
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
@@ -406,6 +437,9 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (!Objects.equals(userCodeNamespace, that.userCodeNamespace)) {
             return false;
         }
+        if (maxConcurrentPublishes != that.maxConcurrentPublishes) {
+            return false;
+        }
         return topicOverloadPolicy == that.topicOverloadPolicy;
     }
 
@@ -418,6 +452,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (topicOverloadPolicy != null ? topicOverloadPolicy.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
+        result = 31 * result + maxConcurrentPublishes;
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -25,6 +25,8 @@ import com.hazelcast.topic.ITopic;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -39,7 +41,7 @@ import static com.hazelcast.internal.util.Preconditions.isNotNull;
  * Contains the configuration for a {@link ITopic}.
  */
 public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Versioned,
-                                    UserCodeNamespaceAwareConfig<TopicConfig> {
+                                    UserCodeNamespaceAwareConfig<TopicConfig>, java.io.Serializable {
 
     /**
      * Default global ordering configuration.
@@ -52,11 +54,17 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
     private boolean multiThreadingEnabled;
     private List<ListenerConfig> listenerConfigs;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishes = -1;
 
     /**
      * Creates a TopicConfig.
      */
     public TopicConfig() {
+        this(-1);
+    }
+
+    public TopicConfig(int maxConcurrentPublishes) {
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -65,7 +73,12 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
      * @param name the name of the Topic
      */
     public TopicConfig(String name) {
+        this(name, -1);
+    }
+
+    public TopicConfig(String name, int maxConcurrentPublishes) {
         setName(name);
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -74,12 +87,17 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
      * @param config the TopicConfig to clone
      */
     public TopicConfig(TopicConfig config) {
+        this(config, -1);
+    }
+
+    public TopicConfig(TopicConfig config, int maxConcurrentPublishes) {
         isNotNull(config, "config");
         this.name = config.name;
         this.globalOrderingEnabled = config.globalOrderingEnabled;
         this.multiThreadingEnabled = config.multiThreadingEnabled;
         this.listenerConfigs = new ArrayList<>(config.getMessageListenerConfigs());
         this.userCodeNamespace = config.userCodeNamespace;
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
     }
 
     /**
@@ -161,6 +179,18 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
             throw new IllegalArgumentException("Multi-threading can not be enabled when global ordering is used.");
         }
         this.multiThreadingEnabled = multiThreadingEnabled;
+        return this;
+    }
+
+    public int getMaxConcurrentPublishes() {
+        return maxConcurrentPublishes;
+    }
+
+    public TopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        if (maxConcurrentPublishes < -1) {
+            throw new IllegalArgumentException("maxConcurrentPublishes must be >= -1");
+        }
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
         return this;
     }
 
@@ -273,6 +303,9 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         if (!Objects.equals(userCodeNamespace, that.userCodeNamespace)) {
             return false;
         }
+        if (maxConcurrentPublishes != that.maxConcurrentPublishes) {
+            return false;
+        }
         return name != null ? name.equals(that.name) : that.name == null;
     }
 
@@ -285,6 +318,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         result = 31 * result + (multiThreadingEnabled ? 1 : 0);
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
+        result = 31 * result + maxConcurrentPublishes;
         return result;
     }
 
@@ -295,6 +329,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
                 + ", multiThreadingEnabled=" + multiThreadingEnabled
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishes=" + maxConcurrentPublishes
                 + "]";
     }
 
@@ -315,6 +350,7 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         out.writeBoolean(statisticsEnabled);
         out.writeBoolean(multiThreadingEnabled);
         writeNullableList(listenerConfigs, out);
+        out.writeInt(maxConcurrentPublishes);
 
         // RU_COMPAT_5_3
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
@@ -329,10 +365,23 @@ public class TopicConfig implements IdentifiedDataSerializable, NamedConfig, Ver
         statisticsEnabled = in.readBoolean();
         multiThreadingEnabled = in.readBoolean();
         listenerConfigs = readNullableList(in);
+        maxConcurrentPublishes = in.readInt();
 
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
             userCodeNamespace = in.readString();
+        }
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        try {
+            in.defaultReadObject();
+        } catch (IOException e) {
+            maxConcurrentPublishes = -1;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricDescriptorConstants.java
@@ -577,6 +577,8 @@ public final class MetricDescriptorConstants {
     public static final String TOPIC_METRIC_CREATION_TIME = "creationTime";
     public static final String TOPIC_METRIC_TOTAL_PUBLISHES = "totalPublishes";
     public static final String TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES = "totalReceivedMessages";
+    public static final String TOPIC_METRIC_REJECTED_PUBLISHES = "rejectedPublishes";
+    public static final String TOPIC_METRIC_IN_FLIGHT_PUBLISHES = "inFlightPublishes";
     // ===[/TOPIC]=======================================================
 
     // ===[TRANSACTIONS]================================================

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
@@ -21,9 +21,12 @@ import com.hazelcast.internal.util.Clock;
 import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.impl.reliable.ReliableMessageRunner;
 
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_CREATION_TIME;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_IN_FLIGHT_PUBLISHES;
+import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_REJECTED_PUBLISHES;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_TOTAL_PUBLISHES;
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES;
 import static com.hazelcast.internal.metrics.ProbeUnit.MS;
@@ -43,6 +46,9 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     private volatile long totalPublishes;
     @Probe(name = TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES)
     private volatile long totalReceivedMessages;
+
+    private final AtomicLong rejectedPublishes = new AtomicLong();
+    private final AtomicLong inFlightPublishes = new AtomicLong();
 
     public LocalTopicStatsImpl() {
         creationTime = Clock.currentTimeMillis();
@@ -87,12 +93,36 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }
 
+    public void incrementRejectedPublishes() {
+        rejectedPublishes.incrementAndGet();
+    }
+
+    public void incrementInFlightPublishes() {
+        inFlightPublishes.incrementAndGet();
+    }
+
+    public void decrementInFlightPublishes() {
+        inFlightPublishes.decrementAndGet();
+    }
+
+    @Probe(name = TOPIC_METRIC_REJECTED_PUBLISHES)
+    public long getRejectedPublishes() {
+        return rejectedPublishes.get();
+    }
+
+    @Probe(name = TOPIC_METRIC_IN_FLIGHT_PUBLISHES)
+    public long getInFlightPublishes() {
+        return inFlightPublishes.get();
+    }
+
     @Override
     public String toString() {
         return "LocalTopicStatsImpl{"
                 + "creationTime=" + creationTime
                 + ", totalPublishes=" + totalPublishes
                 + ", totalReceivedMessages=" + totalReceivedMessages
+                + ", rejectedPublishes=" + rejectedPublishes
+                + ", inFlightPublishes=" + inFlightPublishes
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadedException.java
@@ -1,0 +1,13 @@
+package com.hazelcast.topic;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Exception thrown when a topic is overloaded with concurrent publish operations.
+ * Clients may retry the publish at a later time.
+ */
+public class TopicOverloadedException extends HazelcastException {
+    public TopicOverloadedException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ConcurrentTopicProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ConcurrentTopicProcessor.java
@@ -1,0 +1,49 @@
+package com.hazelcast.topic.impl.reliable;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provides access to the configured maximum concurrent publish operations.
+ * The setting can be changed dynamically through system properties.
+ */
+public class ConcurrentTopicProcessor {
+
+    /**
+     * Name of the system property controlling the maximum concurrent publishes.
+     */
+    public static final HazelcastProperty MAX_CONCURRENT_PUBLISHES_PROPERTY =
+            new HazelcastProperty("hazelcast.topic.max_concurrent_publishes", -1);
+
+    private final HazelcastProperties properties;
+    private final AtomicInteger currentLimit = new AtomicInteger(-1);
+
+    public ConcurrentTopicProcessor(HazelcastInstance instance) {
+        HazelcastInstanceImpl impl = (HazelcastInstanceImpl) instance;
+        this.properties = impl.node.getNodeEngine().getProperties();
+        int initial = properties.getInteger(MAX_CONCURRENT_PUBLISHES_PROPERTY);
+        this.currentLimit.set(validate(initial));
+    }
+
+    private int validate(int value) {
+        if (value < -1 || value > 16) {
+            return -1;
+        }
+        return value;
+    }
+
+    /**
+     * Returns the currently configured limit. The value is read from the
+     * system properties on each invocation to pick up dynamic changes.
+     */
+    public int getCurrentLimit() {
+        int configured = properties.getInteger(MAX_CONCURRENT_PUBLISHES_PROPERTY);
+        int validated = validate(configured);
+        currentLimit.set(validated);
+        return validated;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.internal.monitor.impl.LocalTopicStatsImpl;
+import com.hazelcast.topic.TopicOverloadedException;
 import com.hazelcast.internal.namespace.NamespaceUtil;
 import com.hazelcast.internal.nio.ClassLoaderUtil;
 import com.hazelcast.internal.serialization.Data;
@@ -38,6 +39,7 @@ import com.hazelcast.topic.MessageListener;
 import com.hazelcast.topic.ReliableMessageListener;
 import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import com.hazelcast.topic.impl.reliable.ConcurrentTopicProcessor;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
@@ -49,6 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import java.util.concurrent.Semaphore;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.internal.util.ExceptionUtil.peel;
@@ -88,6 +91,10 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     private final Address thisAddress;
     private final String name;
 
+    private final ConcurrentTopicProcessor concurrentTopicProcessor;
+    private volatile Semaphore publishSemaphore;
+    private volatile int semaphoreLimit = -1;
+
     public ReliableTopicProxy(String name, NodeEngine nodeEngine, ReliableTopicService service,
                               ReliableTopicConfig topicConfig) {
         super(nodeEngine, service);
@@ -100,6 +107,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         this.thisAddress = nodeEngine.getThisAddress();
         this.overloadPolicy = topicConfig.getTopicOverloadPolicy();
         this.localTopicStats = service.getLocalTopicStats(name);
+        this.concurrentTopicProcessor = new ConcurrentTopicProcessor(nodeEngine.getHazelcastInstance());
 
         for (ListenerConfig listenerConfig : topicConfig.getMessageListenerConfigs()) {
             addMessageListener(listenerConfig);
@@ -167,6 +175,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     @Override
     public void publish(@Nonnull E payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
+        int limit = getEffectiveLimit();
+        Semaphore semaphore = acquirePermit(limit);
         try {
             Data data = nodeEngine.toData(payload);
             ReliableTopicMessage message = new ReliableTopicMessage(data, thisAddress);
@@ -189,6 +199,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         } catch (Exception e) {
             throw (RuntimeException) peel(e, null,
                     "Failed to publish message: " + payload + " to topic:" + getName());
+        } finally {
+            releasePermit(semaphore);
         }
     }
 
@@ -280,7 +292,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     public void publishAll(@Nonnull Collection<? extends E> payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
         checkNoNullInside(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
-
+        int limit = getEffectiveLimit();
+        Semaphore semaphore = acquirePermit(limit);
         try {
             List<ReliableTopicMessage> messages = payload.stream()
                     .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
@@ -308,6 +321,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         } catch (Exception e) {
             throw (RuntimeException) peel(e, null,
                     String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
+        } finally {
+            releasePermit(semaphore);
         }
     }
 
@@ -317,6 +332,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         checkNoNullInside(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
 
         InternalCompletableFuture<Void> returnFuture = new InternalCompletableFuture<>();
+        int limit = getEffectiveLimit();
+        Semaphore semaphore = acquirePermit(limit);
         try {
             List<ReliableTopicMessage> messages = payload.stream()
                     .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
@@ -342,7 +359,60 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
                     String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
         }
 
+        if (semaphore != null) {
+            returnFuture.whenComplete((r, t) -> releasePermit(semaphore));
+        }
+
         return returnFuture;
+    }
+
+    private int getEffectiveLimit() {
+        int limit = topicConfig.getMaxConcurrentPublishes();
+        if (limit < 0) {
+            limit = concurrentTopicProcessor.getCurrentLimit();
+        }
+        return limit;
+    }
+
+    private Semaphore acquirePermit(int limit) {
+        if (limit < 0) {
+            return null;
+        }
+        Semaphore sem = ensureSemaphore(limit);
+        boolean acquired;
+        try {
+            acquired = sem.tryAcquire(10, MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            acquired = false;
+        }
+        if (!acquired) {
+            localTopicStats.incrementRejectedPublishes();
+            throw new TopicOverloadedException("Topic [" + name + "] overloaded: maximum concurrent publishes exceeded [" + limit + "]");
+        }
+        localTopicStats.incrementInFlightPublishes();
+        return sem;
+    }
+
+    private Semaphore ensureSemaphore(int limit) {
+        Semaphore sem = publishSemaphore;
+        if (sem == null || semaphoreLimit != limit) {
+            synchronized (this) {
+                if (publishSemaphore == null || semaphoreLimit != limit) {
+                    publishSemaphore = new Semaphore(limit, true);
+                    semaphoreLimit = limit;
+                }
+                sem = publishSemaphore;
+            }
+        }
+        return sem;
+    }
+
+    private void releasePermit(Semaphore sem) {
+        if (sem != null) {
+            sem.release();
+            localTopicStats.decrementInFlightPublishes();
+        }
     }
 
     private void addAsyncOrFail(@Nonnull Collection<? extends E> payload, InternalCompletableFuture<Void> returnFuture,


### PR DESCRIPTION
## Summary
- add `ConcurrentTopicProcessor` to expose configurable publish concurrency limit
- track rejected and in-flight publishes in `LocalTopicStatsImpl`
- allow per-topic limits via `TopicConfig` and `ReliableTopicConfig`
- enforce permit-based publish limiting in `ReliableTopicProxy`

## Testing
- `mvn -q -pl :hazelcast -am test-compile` *(fails: Plugin co.leantechniques:maven-buildtime-extension:3.0.5 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a763eb64d88326b599b3e46a1e3b84