### PR TITLE
Add concurrency limit for reliable topic publishing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -82,6 +82,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
     private List<ListenerConfig> listenerConfigs = new LinkedList<>();
     private TopicOverloadPolicy topicOverloadPolicy = DEFAULT_TOPIC_OVERLOAD_POLICY;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishes = -1;
 
     public ReliableTopicConfig() {
     }
@@ -90,7 +91,12 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      * Creates a new ReliableTopicConfig with default settings.
      */
     public ReliableTopicConfig(String name) {
+        this(name, -1);
+    }
+
+    public ReliableTopicConfig(String name, int maxConcurrentPublishes) {
         this.name = checkNotNull(name, "name");
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -99,6 +105,18 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      * @param config the ReliableTopicConfig to clone
      */
     public ReliableTopicConfig(ReliableTopicConfig config) {
+        this(config, config.name, config.maxConcurrentPublishes);
+    }
+
+    public ReliableTopicConfig(ReliableTopicConfig config, int maxConcurrentPublishes) {
+        this(config, config.name, maxConcurrentPublishes);
+    }
+
+    ReliableTopicConfig(ReliableTopicConfig config, String name) {
+        this(config, name, config.maxConcurrentPublishes);
+    }
+
+    ReliableTopicConfig(ReliableTopicConfig config, String name, int maxConcurrentPublishes) {
         this.name = config.name;
         this.statisticsEnabled = config.statisticsEnabled;
         this.readBatchSize = config.readBatchSize;
@@ -106,11 +124,8 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         this.topicOverloadPolicy = config.topicOverloadPolicy;
         this.listenerConfigs = config.listenerConfigs;
         this.userCodeNamespace = config.userCodeNamespace;
-    }
-
-    ReliableTopicConfig(ReliableTopicConfig config, String name) {
-        this(config);
         this.name = name;
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
     }
 
     /**
@@ -190,6 +205,18 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      */
     public ReliableTopicConfig setExecutor(Executor executor) {
         this.executor = executor;
+        return this;
+    }
+
+    public int getMaxConcurrentPublishes() {
+        return maxConcurrentPublishes;
+    }
+
+    public ReliableTopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        if (maxConcurrentPublishes < -1) {
+            throw new IllegalArgumentException("maxConcurrentPublishes must be >= -1");
+        }
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
         return this;
     }
 
@@ -335,6 +362,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", listenerConfigs=" + listenerConfigs
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishes=" + maxConcurrentPublishes
                 + '}';
     }
 
@@ -361,6 +389,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
             out.writeString(userCodeNamespace);
         }
+        out.writeInt(maxConcurrentPublishes);
     }
 
     @Override
@@ -375,6 +404,11 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
             userCodeNamespace = in.readString();
+        }
+        try {
+            maxConcurrentPublishes = in.readInt();
+        } catch (IOException e) {
+            maxConcurrentPublishes = -1;
         }
     }
 
@@ -406,7 +440,10 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (!Objects.equals(userCodeNamespace, that.userCodeNamespace)) {
             return false;
         }
-        return topicOverloadPolicy == that.topicOverloadPolicy;
+        if (topicOverloadPolicy != that.topicOverloadPolicy) {
+            return false;
+        }
+        return maxConcurrentPublishes == that.maxConcurrentPublishes;
     }
 
     @Override
@@ -418,6 +455,21 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (topicOverloadPolicy != null ? topicOverloadPolicy.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
+        result = 31 * result + maxConcurrentPublishes;
         return result;
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        // When deserializing objects created with older versions where the field
+        // did not exist, the JVM sets it to the default int value (0). Use -1 as
+        // the default to preserve backward compatibility.
+        if (maxConcurrentPublishes == 0) {
+            maxConcurrentPublishes = -1;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
@@ -35,6 +35,10 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
             newUpdater(LocalTopicStatsImpl.class, "totalPublishes");
     private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_RECEIVED_MESSAGES =
             newUpdater(LocalTopicStatsImpl.class, "totalReceivedMessages");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> REJECTED_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "rejectedPublishes");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> IN_FLIGHT_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "inFlightPublishes");
     @Probe(name = TOPIC_METRIC_CREATION_TIME, unit = MS)
     private final long creationTime;
 
@@ -43,6 +47,10 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     private volatile long totalPublishes;
     @Probe(name = TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES)
     private volatile long totalReceivedMessages;
+    @Probe
+    private volatile long rejectedPublishes;
+    @Probe
+    private volatile long inFlightPublishes;
 
     public LocalTopicStatsImpl() {
         creationTime = Clock.currentTimeMillis();
@@ -75,6 +83,14 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         return totalReceivedMessages;
     }
 
+    public long getRejectedPublishes() {
+        return rejectedPublishes;
+    }
+
+    public long getInFlightPublishes() {
+        return inFlightPublishes;
+    }
+
     /**
      * Increment the number of locally received messages. The count can be local
      * to the member or local to a single listener (whereas there are many listeners
@@ -87,12 +103,26 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }
 
+    public void incrementRejectedPublishes() {
+        REJECTED_PUBLISHES.incrementAndGet(this);
+    }
+
+    public void incrementInFlightPublishes() {
+        IN_FLIGHT_PUBLISHES.incrementAndGet(this);
+    }
+
+    public void decrementInFlightPublishes() {
+        IN_FLIGHT_PUBLISHES.decrementAndGet(this);
+    }
+
     @Override
     public String toString() {
         return "LocalTopicStatsImpl{"
                 + "creationTime=" + creationTime
                 + ", totalPublishes=" + totalPublishes
                 + ", totalReceivedMessages=" + totalReceivedMessages
+                + ", rejectedPublishes=" + rejectedPublishes
+                + ", inFlightPublishes=" + inFlightPublishes
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadedException.java
@@ -1,0 +1,14 @@
+package com.hazelcast.topic;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Exception thrown when a topic cannot accept more publish operations due to
+ * configured concurrency limits.
+ */
+public class TopicOverloadedException extends HazelcastException {
+
+    public TopicOverloadedException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ConcurrentTopicProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ConcurrentTopicProcessor.java
@@ -1,0 +1,48 @@
+package com.hazelcast.topic.impl.reliable;
+
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+
+/**
+ * Utility processor that keeps track of the global configuration limiting the
+ * number of concurrent publish operations for topics.
+ */
+public class ConcurrentTopicProcessor {
+
+    /**
+     * System property controlling the maximum allowed concurrent publishes.
+     * A value of {@code -1} disables the limit. Valid range is {@code -1..16}.
+     */
+    public static final HazelcastProperty MAX_CONCURRENT_PUBLISHES_PROPERTY =
+            new HazelcastProperty("hazelcast.topic.max_concurrent_publishes", -1);
+
+    private final HazelcastProperties properties;
+    private volatile int currentLimit;
+
+    public ConcurrentTopicProcessor(HazelcastProperties properties) {
+        this.properties = properties;
+        refreshLimit();
+    }
+
+    /**
+     * Refreshes the current limit from the {@link HazelcastProperties} to allow
+     * dynamic configuration changes.
+     */
+    public final void refreshLimit() {
+        int limit = properties.getInteger(MAX_CONCURRENT_PUBLISHES_PROPERTY);
+        if (limit < -1) {
+            limit = -1;
+        } else if (limit > 16) {
+            limit = 16;
+        }
+        this.currentLimit = limit;
+    }
+
+    /**
+     * Returns the currently configured global limit. A negative value indicates
+     * that no limit is enforced.
+     */
+    public int getCurrentLimit() {
+        return currentLimit;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -19,7 +19,6 @@ package com.hazelcast.topic.impl.reliable;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.ReliableTopicConfig;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.internal.monitor.impl.LocalTopicStatsImpl;
 import com.hazelcast.internal.namespace.NamespaceUtil;
@@ -37,6 +36,7 @@ import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.MessageListener;
 import com.hazelcast.topic.ReliableMessageListener;
 import com.hazelcast.topic.TopicOverloadException;
+import com.hazelcast.topic.TopicOverloadedException;
 import com.hazelcast.topic.TopicOverloadPolicy;
 
 import javax.annotation.Nonnull;
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
@@ -83,6 +84,9 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     final LocalTopicStatsImpl localTopicStats;
     final ReliableTopicConfig topicConfig;
     final TopicOverloadPolicy overloadPolicy;
+    private final ConcurrentTopicProcessor concurrentTopicProcessor;
+    private volatile Semaphore publishSemaphore;
+    private volatile int currentConcurrencyLimit = -1;
 
     private final NodeEngine nodeEngine;
     private final Address thisAddress;
@@ -100,10 +104,32 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         this.thisAddress = nodeEngine.getThisAddress();
         this.overloadPolicy = topicConfig.getTopicOverloadPolicy();
         this.localTopicStats = service.getLocalTopicStats(name);
+        this.concurrentTopicProcessor = new ConcurrentTopicProcessor(nodeEngine.getProperties());
 
         for (ListenerConfig listenerConfig : topicConfig.getMessageListenerConfigs()) {
             addMessageListener(listenerConfig);
         }
+    }
+
+    private Semaphore getPublishSemaphore() {
+        int limit = topicConfig.getMaxConcurrentPublishes();
+        if (limit < 0) {
+            limit = concurrentTopicProcessor.getCurrentLimit();
+        }
+        if (limit < 0) {
+            return null;
+        }
+        Semaphore sem = publishSemaphore;
+        if (sem == null || currentConcurrencyLimit != limit) {
+            synchronized (this) {
+                if (publishSemaphore == null || currentConcurrencyLimit != limit) {
+                    publishSemaphore = new Semaphore(limit, true);
+                    currentConcurrencyLimit = limit;
+                }
+                sem = publishSemaphore;
+            }
+        }
+        return sem;
     }
 
     @Override
@@ -167,7 +193,18 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     @Override
     public void publish(@Nonnull E payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
+        Semaphore sem = getPublishSemaphore();
+        boolean acquired = false;
         try {
+            if (sem != null) {
+                acquired = sem.tryAcquire(10, MILLISECONDS);
+                if (!acquired) {
+                    localTopicStats.incrementRejectedPublishes();
+                    int limit = currentConcurrencyLimit;
+                    throw new TopicOverloadedException("Topic [" + getName() + "] overloaded: maximum concurrent publishes exceeded [" + limit + "]");
+                }
+            }
+            localTopicStats.incrementInFlightPublishes();
             Data data = nodeEngine.toData(payload);
             ReliableTopicMessage message = new ReliableTopicMessage(data, thisAddress);
             switch (overloadPolicy) {
@@ -189,15 +226,43 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         } catch (Exception e) {
             throw (RuntimeException) peel(e, null,
                     "Failed to publish message: " + payload + " to topic:" + getName());
+        } finally {
+            if (sem != null && acquired) {
+                sem.release();
+            }
+            localTopicStats.decrementInFlightPublishes();
         }
     }
 
     @Override
     public CompletionStage<Void> publishAsync(@Nonnull E payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
-
+        Semaphore sem = getPublishSemaphore();
+        boolean acquired;
+        try {
+            if (sem != null) {
+                acquired = sem.tryAcquire(10, MILLISECONDS);
+                if (!acquired) {
+                    localTopicStats.incrementRejectedPublishes();
+                    int limit = currentConcurrencyLimit;
+                    throw new TopicOverloadedException("Topic [" + getName() + "] overloaded: maximum concurrent publishes exceeded [" + limit + "]");
+                }
+            } else {
+                acquired = false;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TopicOverloadedException("Topic [" + getName() + "] overloaded: maximum concurrent publishes exceeded");
+        }
+        localTopicStats.incrementInFlightPublishes();
         Collection<E> messages = Collections.singleton(payload);
-        return publishAllAsync(messages);
+        CompletionStage<Void> stage = publishAllAsync(messages);
+        return stage.whenComplete((r, t) -> {
+            if (sem != null && acquired) {
+                sem.release();
+            }
+            localTopicStats.decrementInFlightPublishes();
+        });
     }
 
     private Long addOrOverwrite(ReliableTopicMessage message) throws Exception {


### PR DESCRIPTION
## Summary
- add `ConcurrentTopicProcessor` with configurable max concurrent publishes
- track rejected and in-flight publishes in `LocalTopicStatsImpl`
- support per-topic concurrency limit via `ReliableTopicConfig` and enforce in `ReliableTopicProxy`

## Testing
- `mvn -q -pl hazelcast -am test -Dtest=LocalTopicStatsImplTest -Dmaven.ext.class.path=` *(fails: Plugin co.leantechniques:maven-buildtime-extension:3.0.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a885d7a8748326b2c7f084858ef0a6