### PR TITLE
Add concurrent publish limits to reliable topics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import java.io.EOFException;
 import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.TopicOverloadPolicy;
@@ -82,15 +83,26 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
     private List<ListenerConfig> listenerConfigs = new LinkedList<>();
     private TopicOverloadPolicy topicOverloadPolicy = DEFAULT_TOPIC_OVERLOAD_POLICY;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishes = -1;
 
     public ReliableTopicConfig() {
+        this(-1);
+    }
+
+    public ReliableTopicConfig(int maxConcurrentPublishes) {
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
      * Creates a new ReliableTopicConfig with default settings.
      */
     public ReliableTopicConfig(String name) {
+        this(name, -1);
+    }
+
+    public ReliableTopicConfig(String name, int maxConcurrentPublishes) {
         this.name = checkNotNull(name, "name");
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -99,6 +111,18 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      * @param config the ReliableTopicConfig to clone
      */
     public ReliableTopicConfig(ReliableTopicConfig config) {
+        this(config, config.name, config.maxConcurrentPublishes);
+    }
+
+    public ReliableTopicConfig(ReliableTopicConfig config, int maxConcurrentPublishes) {
+        this(config, config.name, maxConcurrentPublishes);
+    }
+
+    ReliableTopicConfig(ReliableTopicConfig config, String name) {
+        this(config, name, config.maxConcurrentPublishes);
+    }
+
+    ReliableTopicConfig(ReliableTopicConfig config, String name, int maxConcurrentPublishes) {
         this.name = config.name;
         this.statisticsEnabled = config.statisticsEnabled;
         this.readBatchSize = config.readBatchSize;
@@ -106,11 +130,8 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         this.topicOverloadPolicy = config.topicOverloadPolicy;
         this.listenerConfigs = config.listenerConfigs;
         this.userCodeNamespace = config.userCodeNamespace;
-    }
-
-    ReliableTopicConfig(ReliableTopicConfig config, String name) {
-        this(config);
         this.name = name;
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -155,6 +176,18 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      */
     public ReliableTopicConfig setTopicOverloadPolicy(TopicOverloadPolicy topicOverloadPolicy) {
         this.topicOverloadPolicy = checkNotNull(topicOverloadPolicy, "topicOverloadPolicy can't be null");
+        return this;
+    }
+
+    public int getMaxConcurrentPublishes() {
+        return maxConcurrentPublishes;
+    }
+
+    public ReliableTopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        if (maxConcurrentPublishes < -1) {
+            throw new IllegalArgumentException("maxConcurrentPublishes must be >= -1");
+        }
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
         return this;
     }
 
@@ -325,6 +358,17 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         return this;
     }
 
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (maxConcurrentPublishes == 0) {
+            maxConcurrentPublishes = -1;
+        }
+    }
+
     @Override
     public String toString() {
         return "ReliableTopicConfig{"
@@ -335,6 +379,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", listenerConfigs=" + listenerConfigs
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishes=" + maxConcurrentPublishes
                 + '}';
     }
 
@@ -361,6 +406,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
             out.writeString(userCodeNamespace);
         }
+        out.writeInt(maxConcurrentPublishes);
     }
 
     @Override
@@ -375,6 +421,11 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
             userCodeNamespace = in.readString();
+        }
+        try {
+            maxConcurrentPublishes = in.readInt();
+        } catch (EOFException e) {
+            maxConcurrentPublishes = -1;
         }
     }
 
@@ -406,7 +457,10 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (!Objects.equals(userCodeNamespace, that.userCodeNamespace)) {
             return false;
         }
-        return topicOverloadPolicy == that.topicOverloadPolicy;
+        if (topicOverloadPolicy != that.topicOverloadPolicy) {
+            return false;
+        }
+        return maxConcurrentPublishes == that.maxConcurrentPublishes;
     }
 
     @Override
@@ -418,6 +472,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (topicOverloadPolicy != null ? topicOverloadPolicy.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
+        result = 31 * result + maxConcurrentPublishes;
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ReliableTopicConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ReliableTopicConfigReadOnly.java
@@ -55,6 +55,11 @@ public class ReliableTopicConfigReadOnly extends ReliableTopicConfig {
     }
 
     @Override
+    public ReliableTopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        throw new UnsupportedOperationException("This config is read-only");
+    }
+
+    @Override
     public ReliableTopicConfig setUserCodeNamespace(@Nullable String userCodeNamespace) {
         throw new UnsupportedOperationException("This config is read-only");
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.util.Clock;
 import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.impl.reliable.ReliableMessageRunner;
 
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.internal.metrics.MetricDescriptorConstants.TOPIC_METRIC_CREATION_TIME;
@@ -43,6 +44,9 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     private volatile long totalPublishes;
     @Probe(name = TOPIC_METRIC_TOTAL_RECEIVED_MESSAGES)
     private volatile long totalReceivedMessages;
+
+    private final AtomicLong rejectedPublishes = new AtomicLong();
+    private final AtomicLong inFlightPublishes = new AtomicLong();
 
     public LocalTopicStatsImpl() {
         creationTime = Clock.currentTimeMillis();
@@ -87,12 +91,34 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }
 
+    public void incrementRejectedPublishes() {
+        rejectedPublishes.incrementAndGet();
+    }
+
+    public void incrementInFlightPublishes() {
+        inFlightPublishes.incrementAndGet();
+    }
+
+    public void decrementInFlightPublishes() {
+        inFlightPublishes.decrementAndGet();
+    }
+
+    public long getRejectedPublishes() {
+        return rejectedPublishes.get();
+    }
+
+    public long getInFlightPublishes() {
+        return inFlightPublishes.get();
+    }
+
     @Override
     public String toString() {
         return "LocalTopicStatsImpl{"
                 + "creationTime=" + creationTime
                 + ", totalPublishes=" + totalPublishes
                 + ", totalReceivedMessages=" + totalReceivedMessages
+                + ", rejectedPublishes=" + rejectedPublishes
+                + ", inFlightPublishes=" + inFlightPublishes
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadedException.java
@@ -1,0 +1,14 @@
+package com.hazelcast.topic;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Exception thrown when the maximum number of concurrent publish operations
+ * on a reliable topic is exceeded.
+ */
+public class TopicOverloadedException extends HazelcastException {
+
+    public TopicOverloadedException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ConcurrentTopicProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ConcurrentTopicProcessor.java
@@ -1,0 +1,69 @@
+package com.hazelcast.topic.impl.reliable;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+
+/**
+ * Processor responsible for determining the global concurrent publish limit
+ * for reliable topics. The value is fetched from the Hazelcast properties
+ * and can be refreshed at runtime.
+ */
+public class ConcurrentTopicProcessor {
+
+    /**
+     * System property that defines the maximum number of concurrent publish
+     * operations allowed on a topic. A value of {@code -1} disables
+     * limiting. Valid range is {@code -1} to {@code 16}.
+     */
+    public static final HazelcastProperty MAX_CONCURRENT_PUBLISHES_PROPERTY =
+            new HazelcastProperty("hazelcast.topic.max_concurrent_publishes", -1);
+
+    private final HazelcastInstance hazelcastInstance;
+    private volatile int currentLimit = -1;
+
+    public ConcurrentTopicProcessor(HazelcastInstance hazelcastInstance) {
+        this.hazelcastInstance = hazelcastInstance;
+        refreshLimit();
+    }
+
+    /**
+     * Returns the current global concurrent publish limit.
+     */
+    public int getCurrentLimit() {
+        return currentLimit;
+    }
+
+    /**
+     * Refreshes the limit value by reading the corresponding Hazelcast
+     * property. Invalid values fall back to {@code -1} (unrestricted).
+     */
+    public void refreshLimit() {
+        int limit = -1;
+        HazelcastProperties properties = null;
+        if (hazelcastInstance instanceof HazelcastInstanceImpl) {
+            properties = ((HazelcastInstanceImpl) hazelcastInstance).node.getProperties();
+        }
+        if (properties != null) {
+            try {
+                limit = properties.getInteger(MAX_CONCURRENT_PUBLISHES_PROPERTY);
+            } catch (Exception ignored) {
+                limit = -1;
+            }
+        } else {
+            String prop = System.getProperty(MAX_CONCURRENT_PUBLISHES_PROPERTY.getName(), "-1");
+            try {
+                limit = Integer.parseInt(prop);
+            } catch (NumberFormatException ignored) {
+                limit = -1;
+            }
+        }
+        if (limit < -1) {
+            limit = -1;
+        } else if (limit > 16) {
+            limit = 16;
+        }
+        this.currentLimit = limit;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -37,6 +37,7 @@ import com.hazelcast.topic.LocalTopicStats;
 import com.hazelcast.topic.MessageListener;
 import com.hazelcast.topic.ReliableMessageListener;
 import com.hazelcast.topic.TopicOverloadException;
+import com.hazelcast.topic.TopicOverloadedException;
 import com.hazelcast.topic.TopicOverloadPolicy;
 
 import javax.annotation.Nonnull;
@@ -48,6 +49,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.internal.util.ConcurrencyUtil.CALLER_RUNS;
@@ -83,6 +85,9 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     final LocalTopicStatsImpl localTopicStats;
     final ReliableTopicConfig topicConfig;
     final TopicOverloadPolicy overloadPolicy;
+    final ConcurrentTopicProcessor concurrentTopicProcessor;
+    final int publishLimit;
+    final Semaphore publishSemaphore;
 
     private final NodeEngine nodeEngine;
     private final Address thisAddress;
@@ -100,6 +105,11 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         this.thisAddress = nodeEngine.getThisAddress();
         this.overloadPolicy = topicConfig.getTopicOverloadPolicy();
         this.localTopicStats = service.getLocalTopicStats(name);
+        this.concurrentTopicProcessor = new ConcurrentTopicProcessor(nodeEngine.getHazelcastInstance());
+        int configured = topicConfig.getMaxConcurrentPublishes();
+        int global = concurrentTopicProcessor.getCurrentLimit();
+        this.publishLimit = configured >= 0 ? configured : global;
+        this.publishSemaphore = publishLimit >= 0 ? new Semaphore(publishLimit, true) : null;
 
         for (ListenerConfig listenerConfig : topicConfig.getMessageListenerConfigs()) {
             addMessageListener(listenerConfig);
@@ -164,32 +174,36 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         return executor;
     }
 
+    private void acquirePublishPermit() {
+        if (publishSemaphore == null) {
+            return;
+        }
+        boolean acquired;
+        try {
+            acquired = publishSemaphore.tryAcquire(10, MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            acquired = false;
+        }
+        if (!acquired) {
+            localTopicStats.incrementRejectedPublishes();
+            throw new TopicOverloadedException("Topic [" + name + "] overloaded: maximum concurrent publishes exceeded ["
+                    + publishLimit + "]");
+        }
+        localTopicStats.incrementInFlightPublishes();
+    }
+
+    private void releasePublishPermit() {
+        if (publishSemaphore != null) {
+            publishSemaphore.release();
+            localTopicStats.decrementInFlightPublishes();
+        }
+    }
+
     @Override
     public void publish(@Nonnull E payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
-        try {
-            Data data = nodeEngine.toData(payload);
-            ReliableTopicMessage message = new ReliableTopicMessage(data, thisAddress);
-            switch (overloadPolicy) {
-                case ERROR:
-                    addOrFail(message);
-                    break;
-                case DISCARD_OLDEST:
-                    addOrOverwrite(message);
-                    break;
-                case DISCARD_NEWEST:
-                    ringbuffer.addAsync(message, OverflowPolicy.FAIL).toCompletableFuture().get();
-                    break;
-                case BLOCK:
-                    addWithBackoff(Collections.singleton(message));
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
-            }
-        } catch (Exception e) {
-            throw (RuntimeException) peel(e, null,
-                    "Failed to publish message: " + payload + " to topic:" + getName());
-        }
+        publishAll(Collections.singleton(payload));
     }
 
     @Override
@@ -280,7 +294,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     public void publishAll(@Nonnull Collection<? extends E> payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
         checkNoNullInside(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
-
+        acquirePublishPermit();
         try {
             List<ReliableTopicMessage> messages = payload.stream()
                     .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
@@ -308,6 +322,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         } catch (Exception e) {
             throw (RuntimeException) peel(e, null,
                     String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
+        } finally {
+            releasePublishPermit();
         }
     }
 
@@ -315,34 +331,38 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     public CompletionStage<Void> publishAllAsync(@Nonnull Collection<? extends E> payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
         checkNoNullInside(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
-
-        InternalCompletableFuture<Void> returnFuture = new InternalCompletableFuture<>();
+        acquirePublishPermit();
+        InternalCompletableFuture<Void> future;
         try {
             List<ReliableTopicMessage> messages = payload.stream()
                     .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
                     .collect(Collectors.toList());
             switch (overloadPolicy) {
                 case ERROR:
-                    addAsyncOrFail(payload, returnFuture, messages);
+                    future = new InternalCompletableFuture<>();
+                    addAsyncOrFail(payload, future, messages);
                     break;
                 case DISCARD_OLDEST:
-                    addAsync(messages, OverflowPolicy.OVERWRITE);
+                    future = addAsync(messages, OverflowPolicy.OVERWRITE);
                     break;
                 case DISCARD_NEWEST:
-                    addAsync(messages, OverflowPolicy.FAIL);
+                    future = addAsync(messages, OverflowPolicy.FAIL);
                     break;
                 case BLOCK:
-                    addAsyncAndBlock(payload, returnFuture, messages, INITIAL_BACKOFF_MS);
+                    future = new InternalCompletableFuture<>();
+                    addAsyncAndBlock(payload, future, messages, INITIAL_BACKOFF_MS);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
             }
         } catch (Exception e) {
+            releasePublishPermit();
             throw (RuntimeException) peel(e, null,
                     String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
         }
 
-        return returnFuture;
+        future.whenComplete((r, t) -> releasePublishPermit());
+        return future;
     }
 
     private void addAsyncOrFail(@Nonnull Collection<? extends E> payload, InternalCompletableFuture<Void> returnFuture,

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -508,7 +508,8 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getName(), c2.getName())
                     && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
                     && nullSafeEqual(c1.getMessageListenerConfigs(), c2.getMessageListenerConfigs())
-                    && nullSafeEqual(c1.getTopicOverloadPolicy(), c2.getTopicOverloadPolicy());
+                    && nullSafeEqual(c1.getTopicOverloadPolicy(), c2.getTopicOverloadPolicy())
+                    && nullSafeEqual(c1.getMaxConcurrentPublishes(), c2.getMaxConcurrentPublishes());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -55,6 +55,7 @@ public class ReliableTopicConfigTest {
         assertEquals("foo", config.getName());
         assertEquals(DEFAULT_TOPIC_OVERLOAD_POLICY, config.getTopicOverloadPolicy());
         assertEquals(DEFAULT_STATISTICS_ENABLED, config.isStatisticsEnabled());
+        assertEquals(-1, config.getMaxConcurrentPublishes());
     }
 
     @Test
@@ -239,7 +240,8 @@ public class ReliableTopicConfigTest {
         String s = config.toString();
 
         assertEquals("ReliableTopicConfig{name='foo', topicOverloadPolicy=BLOCK, executor=null,"
-                + " readBatchSize=10, statisticsEnabled=true, listenerConfigs=[], userCodeNamespace=null}", s);
+                + " readBatchSize=10, statisticsEnabled=true, listenerConfigs=[], userCodeNamespace=null,"
+                + " maxConcurrentPublishes=-1}", s);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitor/impl/LocalTopicStatsImplTest.java
@@ -43,6 +43,9 @@ public class LocalTopicStatsImplTest {
         localTopicStats.incrementPublishes();
         localTopicStats.incrementReceives();
         localTopicStats.incrementReceives();
+        localTopicStats.incrementRejectedPublishes();
+        localTopicStats.incrementInFlightPublishes();
+        localTopicStats.decrementInFlightPublishes();
     }
 
     @Test
@@ -50,6 +53,8 @@ public class LocalTopicStatsImplTest {
         assertTrue(localTopicStats.getCreationTime() > 0);
         assertEquals(3, localTopicStats.getPublishOperationCount());
         assertEquals(2, localTopicStats.getReceiveOperationCount());
+        assertEquals(1, localTopicStats.getRejectedPublishes());
+        assertEquals(0, localTopicStats.getInFlightPublishes());
         assertNotNull(localTopicStats.toString());
     }
 }


### PR DESCRIPTION
## Summary
- add configurable maxConcurrentPublishes to ReliableTopicConfig with constructors and serialization
- introduce ConcurrentTopicProcessor and TopicOverloadedException
- track rejected and in-flight publishes in LocalTopicStatsImpl
- enforce semaphore-based publish limits in ReliableTopicProxy

## Testing
- `mvn -q -pl hazelcast -am test -Dtest=ReliableTopicConfigTest,LocalTopicStatsImplTest -DfailIfNoTests=false` *(fails: Plugin co.leantechniques:maven-buildtime-extension:3.0.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f29f6b048326b9a75a94a6b78974