### PR TITLE
Add concurrency management for ReliableTopic publishing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import static com.hazelcast.internal.cluster.Versions.V5_4;
+import static com.hazelcast.internal.cluster.Versions.V6_0;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableList;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -75,6 +76,11 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      */
     public static final boolean DEFAULT_STATISTICS_ENABLED = true;
 
+    /**
+     * Default maximum number of concurrent publish operations.
+     */
+    public static final int DEFAULT_MAX_CONCURRENT_PUBLISHES = 1;
+
     private Executor executor;
     private int readBatchSize = DEFAULT_READ_BATCH_SIZE;
     private String name;
@@ -82,6 +88,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
     private List<ListenerConfig> listenerConfigs = new LinkedList<>();
     private TopicOverloadPolicy topicOverloadPolicy = DEFAULT_TOPIC_OVERLOAD_POLICY;
     private @Nullable String userCodeNamespace = DEFAULT_NAMESPACE;
+    private int maxConcurrentPublishes = DEFAULT_MAX_CONCURRENT_PUBLISHES;
 
     public ReliableTopicConfig() {
     }
@@ -91,6 +98,14 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      */
     public ReliableTopicConfig(String name) {
         this.name = checkNotNull(name, "name");
+    }
+
+    /**
+     * Creates a new ReliableTopicConfig with a custom maximum concurrent publishes setting.
+     */
+    public ReliableTopicConfig(String name, int maxConcurrentPublishes) {
+        this(name);
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -106,11 +121,25 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         this.topicOverloadPolicy = config.topicOverloadPolicy;
         this.listenerConfigs = config.listenerConfigs;
         this.userCodeNamespace = config.userCodeNamespace;
+        this.maxConcurrentPublishes = config.maxConcurrentPublishes;
+    }
+
+    /**
+     * Creates a new ReliableTopicConfig by cloning an existing one with a custom maximum concurrent publishes setting.
+     */
+    public ReliableTopicConfig(ReliableTopicConfig config, int maxConcurrentPublishes) {
+        this(config);
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     ReliableTopicConfig(ReliableTopicConfig config, String name) {
         this(config);
         this.name = name;
+    }
+
+    ReliableTopicConfig(ReliableTopicConfig config, String name, int maxConcurrentPublishes) {
+        this(config, name);
+        setMaxConcurrentPublishes(maxConcurrentPublishes);
     }
 
     /**
@@ -155,6 +184,31 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
      */
     public ReliableTopicConfig setTopicOverloadPolicy(TopicOverloadPolicy topicOverloadPolicy) {
         this.topicOverloadPolicy = checkNotNull(topicOverloadPolicy, "topicOverloadPolicy can't be null");
+        return this;
+    }
+
+    /**
+     * Gets the maximum number of concurrent publish operations for this topic.
+     *
+     * @return the maximum number of concurrent publishes
+     */
+    public int getMaxConcurrentPublishes() {
+        return maxConcurrentPublishes;
+    }
+
+    /**
+     * Sets the maximum number of concurrent publish operations for this topic.
+     * The value must be between 1 and 8, inclusive.
+     *
+     * @param maxConcurrentPublishes the concurrency limit
+     * @return the updated reliable topic config
+     * @throws IllegalArgumentException if the value is outside of the allowed range
+     */
+    public ReliableTopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        if (maxConcurrentPublishes < 1 || maxConcurrentPublishes > 8) {
+            throw new IllegalArgumentException("maxConcurrentPublishes must be between 1 and 8");
+        }
+        this.maxConcurrentPublishes = maxConcurrentPublishes;
         return this;
     }
 
@@ -335,6 +389,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", listenerConfigs=" + listenerConfigs
                 + ", userCodeNamespace=" + userCodeNamespace
+                + ", maxConcurrentPublishes=" + maxConcurrentPublishes
                 + '}';
     }
 
@@ -361,6 +416,10 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (out.getVersion().isGreaterOrEqual(V5_4)) {
             out.writeString(userCodeNamespace);
         }
+
+        if (out.getVersion().isGreaterOrEqual(V6_0)) {
+            out.writeInt(maxConcurrentPublishes);
+        }
     }
 
     @Override
@@ -375,6 +434,10 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         // RU_COMPAT_5_3
         if (in.getVersion().isGreaterOrEqual(V5_4)) {
             userCodeNamespace = in.readString();
+        }
+
+        if (in.getVersion().isGreaterOrEqual(V6_0)) {
+            maxConcurrentPublishes = in.readInt();
         }
     }
 
@@ -406,6 +469,9 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         if (!Objects.equals(userCodeNamespace, that.userCodeNamespace)) {
             return false;
         }
+        if (maxConcurrentPublishes != that.maxConcurrentPublishes) {
+            return false;
+        }
         return topicOverloadPolicy == that.topicOverloadPolicy;
     }
 
@@ -418,6 +484,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedCon
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (topicOverloadPolicy != null ? topicOverloadPolicy.hashCode() : 0);
         result = 31 * result + (userCodeNamespace != null ? userCodeNamespace.hashCode() : 0);
+        result = 31 * result + maxConcurrentPublishes;
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ReliableTopicConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ReliableTopicConfigReadOnly.java
@@ -55,6 +55,11 @@ public class ReliableTopicConfigReadOnly extends ReliableTopicConfig {
     }
 
     @Override
+    public ReliableTopicConfig setMaxConcurrentPublishes(int maxConcurrentPublishes) {
+        throw new UnsupportedOperationException("This config is read-only");
+    }
+
+    @Override
     public ReliableTopicConfig setUserCodeNamespace(@Nullable String userCodeNamespace) {
         throw new UnsupportedOperationException("This config is read-only");
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicConcurrencyManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicConcurrencyManager.java
@@ -1,0 +1,118 @@
+package com.hazelcast.topic.impl.reliable;
+
+import com.hazelcast.config.ReliableTopicConfig;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Scheduler for throttling concurrent publish operations for reliable topics.
+ * <p>
+ * The manager limits the number of in-flight publish tasks based on the
+ * {@link ReliableTopicConfig} and exposes instrumentation methods required for
+ * testing.
+ */
+public class ReliableTopicConcurrencyManager {
+
+    private final ReliableTopicConfig config;
+    private final Queue<Task> queue = new ArrayDeque<>();
+    private int inFlight;
+
+    public ReliableTopicConcurrencyManager(ReliableTopicConfig config) {
+        this.config = Objects.requireNonNull(config);
+    }
+
+    /**
+     * Returns the effective concurrency limit.
+     */
+    public int currentLimit() {
+        int limit = config.getMaxConcurrentPublishes();
+        if (limit < 1) {
+            return 1;
+        }
+        return Math.min(limit, 8);
+    }
+
+    /**
+     * Schedules the supplied task subject to the configured concurrency limit.
+     * The task is invoked when capacity permits and the returned stage
+     * completes when the task has finished.
+     */
+    CompletionStage<?> schedule(Supplier<? extends CompletionStage<?>> task) {
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        synchronized (this) {
+            queue.add(new Task(task, future));
+            drain();
+        }
+        return future;
+    }
+
+    /**
+     * Returns the number of publish operations currently in-flight.
+     */
+    int getInFlightCount() {
+        synchronized (this) {
+            return inFlight;
+        }
+    }
+
+    /**
+     * Waits until all queued and in-flight tasks complete or the timeout
+     * expires.
+     */
+    void awaitQuiescence(Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        synchronized (this) {
+            while ((inFlight > 0 || !queue.isEmpty()) && System.nanoTime() < deadline) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    break;
+                }
+                this.wait(remaining / 1_000_000, (int) (remaining % 1_000_000));
+            }
+        }
+    }
+
+    private void drain() {
+        int limit = currentLimit();
+        while (inFlight < limit && !queue.isEmpty()) {
+            Task t = queue.poll();
+            inFlight++;
+            CompletionStage<?> stage;
+            try {
+                stage = t.task.get();
+            } catch (Throwable e) {
+                inFlight--;
+                t.future.completeExceptionally(e);
+                continue;
+            }
+            stage.whenComplete((r, e) -> {
+                if (e != null) {
+                    t.future.completeExceptionally(e);
+                } else {
+                    t.future.complete(r);
+                }
+                synchronized (ReliableTopicConcurrencyManager.this) {
+                    inFlight--;
+                    ReliableTopicConcurrencyManager.this.notifyAll();
+                    drain();
+                }
+            });
+        }
+    }
+
+    private static final class Task {
+        final Supplier<? extends CompletionStage<?>> task;
+        final CompletableFuture<Object> future;
+
+        Task(Supplier<? extends CompletionStage<?>> task, CompletableFuture<Object> future) {
+            this.task = task;
+            this.future = future;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
@@ -83,6 +84,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     final LocalTopicStatsImpl localTopicStats;
     final ReliableTopicConfig topicConfig;
     final TopicOverloadPolicy overloadPolicy;
+    final ReliableTopicConcurrencyManager concurrencyManager;
 
     private final NodeEngine nodeEngine;
     private final Address thisAddress;
@@ -100,6 +102,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         this.thisAddress = nodeEngine.getThisAddress();
         this.overloadPolicy = topicConfig.getTopicOverloadPolicy();
         this.localTopicStats = service.getLocalTopicStats(name);
+        this.concurrencyManager = new ReliableTopicConcurrencyManager(topicConfig);
 
         for (ListenerConfig listenerConfig : topicConfig.getMessageListenerConfigs()) {
             addMessageListener(listenerConfig);
@@ -166,26 +169,8 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
 
     @Override
     public void publish(@Nonnull E payload) {
-        checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
         try {
-            Data data = nodeEngine.toData(payload);
-            ReliableTopicMessage message = new ReliableTopicMessage(data, thisAddress);
-            switch (overloadPolicy) {
-                case ERROR:
-                    addOrFail(message);
-                    break;
-                case DISCARD_OLDEST:
-                    addOrOverwrite(message);
-                    break;
-                case DISCARD_NEWEST:
-                    ringbuffer.addAsync(message, OverflowPolicy.FAIL).toCompletableFuture().get();
-                    break;
-                case BLOCK:
-                    addWithBackoff(Collections.singleton(message));
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
-            }
+            publishAsync(payload).toCompletableFuture().get();
         } catch (Exception e) {
             throw (RuntimeException) peel(e, null,
                     "Failed to publish message: " + payload + " to topic:" + getName());
@@ -195,37 +180,10 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     @Override
     public CompletionStage<Void> publishAsync(@Nonnull E payload) {
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
-
         Collection<E> messages = Collections.singleton(payload);
         return publishAllAsync(messages);
     }
 
-    private Long addOrOverwrite(ReliableTopicMessage message) throws Exception {
-        return ringbuffer.addAsync(message, OverflowPolicy.OVERWRITE).toCompletableFuture().get();
-    }
-
-    private void addOrFail(ReliableTopicMessage message) throws Exception {
-        long sequenceId = ringbuffer.addAsync(message, OverflowPolicy.FAIL).toCompletableFuture().get();
-        if (sequenceId == -1) {
-            throw new TopicOverloadException("Failed to publish message: " + message + " on topic:" + getName());
-        }
-    }
-
-    private void addWithBackoff(Collection<ReliableTopicMessage> messages) throws Exception {
-        long timeoutMs = INITIAL_BACKOFF_MS;
-        for (; ; ) {
-            long result = ringbuffer.addAllAsync(messages, OverflowPolicy.FAIL).toCompletableFuture().get();
-            if (result != -1) {
-                break;
-            }
-
-            MILLISECONDS.sleep(timeoutMs);
-            timeoutMs *= 2;
-            if (timeoutMs > MAX_BACKOFF) {
-                timeoutMs = MAX_BACKOFF;
-            }
-        }
-    }
 
     @Nonnull
     @Override
@@ -282,29 +240,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         checkNoNullInside(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
 
         try {
-            List<ReliableTopicMessage> messages = payload.stream()
-                    .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
-                    .collect(Collectors.toList());
-            switch (overloadPolicy) {
-                case ERROR:
-                    long sequenceId = ringbuffer.addAllAsync(messages, OverflowPolicy.FAIL).toCompletableFuture().get();
-                    if (sequenceId == -1) {
-                        throw new TopicOverloadException(
-                                String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
-                    }
-                    break;
-                case DISCARD_OLDEST:
-                    ringbuffer.addAllAsync(messages, OverflowPolicy.OVERWRITE).toCompletableFuture().get();
-                    break;
-                case DISCARD_NEWEST:
-                    ringbuffer.addAllAsync(messages, OverflowPolicy.FAIL).toCompletableFuture().get();
-                    break;
-                case BLOCK:
-                    addWithBackoff(messages);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
-            }
+            publishAllAsync(payload).toCompletableFuture().get();
         } catch (Exception e) {
             throw (RuntimeException) peel(e, null,
                     String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
@@ -316,33 +252,36 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         checkNotNull(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
         checkNoNullInside(payload, NULL_MESSAGE_IS_NOT_ALLOWED);
 
-        InternalCompletableFuture<Void> returnFuture = new InternalCompletableFuture<>();
-        try {
-            List<ReliableTopicMessage> messages = payload.stream()
-                    .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
-                    .collect(Collectors.toList());
-            switch (overloadPolicy) {
-                case ERROR:
-                    addAsyncOrFail(payload, returnFuture, messages);
-                    break;
-                case DISCARD_OLDEST:
-                    addAsync(messages, OverflowPolicy.OVERWRITE);
-                    break;
-                case DISCARD_NEWEST:
-                    addAsync(messages, OverflowPolicy.FAIL);
-                    break;
-                case BLOCK:
-                    addAsyncAndBlock(payload, returnFuture, messages, INITIAL_BACKOFF_MS);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
-            }
-        } catch (Exception e) {
-            throw (RuntimeException) peel(e, null,
-                    String.format("Failed to publish messages: %s on topic: %s", payload, getName()));
-        }
+        List<ReliableTopicMessage> messages = payload.stream()
+                .map(m -> new ReliableTopicMessage(nodeEngine.toData(m), thisAddress))
+                .collect(Collectors.toList());
 
-        return returnFuture;
+        return (CompletionStage<Void>) concurrencyManager.schedule(() -> {
+            switch (overloadPolicy) {
+                case ERROR: {
+                    InternalCompletableFuture<Void> f = new InternalCompletableFuture<>();
+                    addAsyncOrFail(payload, f, messages);
+                    return f;
+                }
+                case DISCARD_OLDEST:
+                    return addAsync(messages, OverflowPolicy.OVERWRITE);
+                case DISCARD_NEWEST:
+                    return addAsync(messages, OverflowPolicy.FAIL);
+                case BLOCK: {
+                    InternalCompletableFuture<Void> f = new InternalCompletableFuture<>();
+                    addAsyncAndBlock(payload, f, messages, INITIAL_BACKOFF_MS);
+                    return f;
+                }
+                default:
+                    CompletableFuture<Void> f = new CompletableFuture<>();
+                    f.completeExceptionally(new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy));
+                    return f;
+            }
+        });
+    }
+
+    ReliableTopicConcurrencyManager concurrencyManager() {
+        return concurrencyManager;
     }
 
     private void addAsyncOrFail(@Nonnull Collection<? extends E> payload, InternalCompletableFuture<Void> returnFuture,

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -508,7 +508,8 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getName(), c2.getName())
                     && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
                     && nullSafeEqual(c1.getMessageListenerConfigs(), c2.getMessageListenerConfigs())
-                    && nullSafeEqual(c1.getTopicOverloadPolicy(), c2.getTopicOverloadPolicy());
+                    && nullSafeEqual(c1.getTopicOverloadPolicy(), c2.getTopicOverloadPolicy())
+                    && nullSafeEqual(c1.getMaxConcurrentPublishes(), c2.getMaxConcurrentPublishes());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -55,6 +55,7 @@ public class ReliableTopicConfigTest {
         assertEquals("foo", config.getName());
         assertEquals(DEFAULT_TOPIC_OVERLOAD_POLICY, config.getTopicOverloadPolicy());
         assertEquals(DEFAULT_STATISTICS_ENABLED, config.isStatisticsEnabled());
+        assertEquals(1, config.getMaxConcurrentPublishes());
     }
 
     @Test
@@ -76,7 +77,8 @@ public class ReliableTopicConfigTest {
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR)
                 .setExecutor(mock(Executor.class))
                 .setReadBatchSize(1)
-                .setStatisticsEnabled(!DEFAULT_STATISTICS_ENABLED);
+                .setStatisticsEnabled(!DEFAULT_STATISTICS_ENABLED)
+                .setMaxConcurrentPublishes(2);
 
         ReliableTopicConfig copy = new ReliableTopicConfig(original, "copy");
 
@@ -85,6 +87,7 @@ public class ReliableTopicConfigTest {
         assertEquals(original.getReadBatchSize(), copy.getReadBatchSize());
         assertEquals(original.isStatisticsEnabled(), copy.isStatisticsEnabled());
         assertEquals(original.getTopicOverloadPolicy(), copy.getTopicOverloadPolicy());
+        assertEquals(original.getMaxConcurrentPublishes(), copy.getMaxConcurrentPublishes());
     }
 
     @Test
@@ -93,7 +96,8 @@ public class ReliableTopicConfigTest {
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR)
                 .setExecutor(mock(Executor.class))
                 .setReadBatchSize(1)
-                .setStatisticsEnabled(!DEFAULT_STATISTICS_ENABLED);
+                .setStatisticsEnabled(!DEFAULT_STATISTICS_ENABLED)
+                .setMaxConcurrentPublishes(3);
 
         ReliableTopicConfig copy = new ReliableTopicConfig(original);
 
@@ -102,6 +106,32 @@ public class ReliableTopicConfigTest {
         assertEquals(original.getReadBatchSize(), copy.getReadBatchSize());
         assertEquals(original.isStatisticsEnabled(), copy.isStatisticsEnabled());
         assertEquals(original.getTopicOverloadPolicy(), copy.getTopicOverloadPolicy());
+        assertEquals(original.getMaxConcurrentPublishes(), copy.getMaxConcurrentPublishes());
+    }
+
+    @Test
+    public void testMaxConcurrentPublishesConstructor() {
+        ReliableTopicConfig config = new ReliableTopicConfig("foo", 4);
+        assertEquals(4, config.getMaxConcurrentPublishes());
+    }
+
+    @Test
+    public void testSetMaxConcurrentPublishes() {
+        ReliableTopicConfig config = new ReliableTopicConfig("foo");
+        config.setMaxConcurrentPublishes(5);
+        assertEquals(5, config.getMaxConcurrentPublishes());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetMaxConcurrentPublishesTooLow() {
+        ReliableTopicConfig config = new ReliableTopicConfig("foo");
+        config.setMaxConcurrentPublishes(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetMaxConcurrentPublishesTooHigh() {
+        ReliableTopicConfig config = new ReliableTopicConfig("foo");
+        config.setMaxConcurrentPublishes(9);
     }
 
     // ==================== setTopicOverflowPolicy =============================
@@ -235,11 +265,10 @@ public class ReliableTopicConfigTest {
     @Test
     public void test_toString() {
         ReliableTopicConfig config = new ReliableTopicConfig("foo");
-
         String s = config.toString();
-
         assertEquals("ReliableTopicConfig{name='foo', topicOverloadPolicy=BLOCK, executor=null,"
-                + " readBatchSize=10, statisticsEnabled=true, listenerConfigs=[], userCodeNamespace=null}", s);
+                + " readBatchSize=10, statisticsEnabled=true, listenerConfigs=[], userCodeNamespace=null,"
+                + " maxConcurrentPublishes=1}", s);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Introduce `ReliableTopicConcurrencyManager` to throttle and observe in-flight reliable topic publishes
- Extend `ReliableTopicConfig` with maxConcurrentPublishes setting and constructors
- Integrate concurrency manager into `ReliableTopicProxy` and expose testing hooks

## Testing
- `mvn -q -pl hazelcast -am -Dtest=ReliableTopicConfigTest -Dmaven.ext.class.path= test` *(fails: Plugin co.leantechniques:maven-buildtime-extension:3.0.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9700f6008326abf9f49cecc12d16